### PR TITLE
Improve DeepSeek chat handler error handling

### DIFF
--- a/backend/src/chat.js
+++ b/backend/src/chat.js
@@ -1,21 +1,136 @@
 const deepseekBaseURL = "https://api.deepseek.com/v1/chat/completions";
 
+function normalizeMessages(rawMessages) {
+  if (!Array.isArray(rawMessages)) {
+    return null;
+  }
+
+  const normalized = [];
+
+  for (let index = 0; index < rawMessages.length; index += 1) {
+    const entry = rawMessages[index];
+
+    if (!entry || typeof entry !== "object") {
+      return null;
+    }
+
+    const rawRole = typeof entry.role === "string" ? entry.role.trim() : "";
+
+    if (!rawRole) {
+      return null;
+    }
+
+    const role = rawRole.toLowerCase();
+    const contentCandidate = entry.content;
+
+    let textContent = "";
+
+    if (Array.isArray(contentCandidate)) {
+      textContent = contentCandidate
+        .map((part) => {
+          if (typeof part === "string") {
+            return part;
+          }
+
+          if (part && typeof part.text === "string") {
+            return part.text;
+          }
+
+          return "";
+        })
+        .join("");
+    } else if (typeof contentCandidate === "string") {
+      textContent = contentCandidate;
+    } else if (contentCandidate && typeof contentCandidate === "object" && typeof contentCandidate.text === "string") {
+      textContent = contentCandidate.text;
+    } else if (contentCandidate !== undefined && contentCandidate !== null) {
+      textContent = String(contentCandidate);
+    }
+
+    const trimmedContent = textContent.trim();
+
+    if (!trimmedContent) {
+      return null;
+    }
+
+    normalized.push({
+      role,
+      content: trimmedContent,
+    });
+  }
+
+  return normalized;
+}
+
 /** @type {import("express").RequestHandler} */
 export const chat = async (req, res) => {
-  const { messages } = req.body;
-  const data = await fetch(deepseekBaseURL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${process.env.DEEPSEEK_API_KEY}`
-    },
-    body: JSON.stringify({
-      model: "deepseek-chat",
-      messages,
-      max_tokens: 300,
-      temperature: 0.7
-    })
-  }).then((res) => res.json());
+  const normalizedMessages = normalizeMessages(req.body?.messages);
 
-  res.status(200).json(data);
+  if (!normalizedMessages || normalizedMessages.length === 0) {
+    return res.status(400).json({ error: "A non-empty array of chat messages is required." });
+  }
+
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+
+  if (!apiKey) {
+    return res.status(500).json({ error: "DeepSeek API key is not configured." });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, 60000);
+
+  try {
+    const response = await fetch(deepseekBaseURL, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "deepseek-chat",
+        messages: normalizedMessages,
+        max_tokens: 300,
+        temperature: 0.7,
+      }),
+    });
+
+    clearTimeout(timeout);
+
+    const rawText = await response.text();
+    let payload;
+
+    if (rawText) {
+      try {
+        payload = JSON.parse(rawText);
+      } catch (parseError) {
+        payload = { message: rawText };
+      }
+    }
+
+    if (!response.ok) {
+      const errorMessage =
+        payload?.error?.message ||
+        payload?.message ||
+        `DeepSeek request failed with status ${response.status}.`;
+
+      return res
+        .status(response.status)
+        .json({ error: errorMessage, details: payload ?? null });
+    }
+
+    return res.status(200).json(payload ?? {});
+  } catch (error) {
+    clearTimeout(timeout);
+
+    if (error instanceof Error && error.name === "AbortError") {
+      return res.status(504).json({ error: "The DeepSeek request timed out." });
+    }
+
+    const message = error instanceof Error ? error.message : "Unexpected error when contacting DeepSeek.";
+
+    return res.status(502).json({ error: message });
+  }
 };

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,7 +1,16 @@
 import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import "dotenv/config";
 
 const app = express();
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const placeholderPath = path.join(currentDir, "placeholder.json");
+
+app.get("/placeholder.json", (_req, res) => {
+  res.sendFile(placeholderPath);
+});
 
 app.use(express.static("public"));
 

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,6 +1,15 @@
 import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const app = express();
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const placeholderPath = path.join(currentDir, "placeholder.json");
+
+app.get("/placeholder.json", (_req, res) => {
+  res.sendFile(placeholderPath);
+});
 
 app.use(express.static("public"));
 


### PR DESCRIPTION
## Summary
- validate incoming chat messages before proxying to DeepSeek
- add DeepSeek API key checks, timeout handling, and structured error responses
- return parsed DeepSeek payloads only on success so the frontend can show pet replies reliably

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c88f05a1c48322b2f75ffe792ebc29