### PR TITLE
Apply Pokémon roleplay template to chat requests

### DIFF
--- a/backend/src/chat.js
+++ b/backend/src/chat.js
@@ -62,68 +62,6 @@ function normalizeMessages(rawMessages) {
   return normalized;
 }
 
-function normalizeMessages(rawMessages) {
-  if (!Array.isArray(rawMessages)) {
-    return null;
-  }
-
-  const normalized = [];
-
-  for (let index = 0; index < rawMessages.length; index += 1) {
-    const entry = rawMessages[index];
-
-    if (!entry || typeof entry !== "object") {
-      return null;
-    }
-
-    const rawRole = typeof entry.role === "string" ? entry.role.trim() : "";
-
-    if (!rawRole) {
-      return null;
-    }
-
-    const role = rawRole.toLowerCase();
-    const contentCandidate = entry.content;
-
-    let textContent = "";
-
-    if (Array.isArray(contentCandidate)) {
-      textContent = contentCandidate
-        .map((part) => {
-          if (typeof part === "string") {
-            return part;
-          }
-
-          if (part && typeof part.text === "string") {
-            return part.text;
-          }
-
-          return "";
-        })
-        .join("");
-    } else if (typeof contentCandidate === "string") {
-      textContent = contentCandidate;
-    } else if (contentCandidate && typeof contentCandidate === "object" && typeof contentCandidate.text === "string") {
-      textContent = contentCandidate.text;
-    } else if (contentCandidate !== undefined && contentCandidate !== null) {
-      textContent = String(contentCandidate);
-    }
-
-    const trimmedContent = textContent.trim();
-
-    if (!trimmedContent) {
-      return null;
-    }
-
-    normalized.push({
-      role,
-      content: trimmedContent,
-    });
-  }
-
-  return normalized;
-}
-
 /** @type {import("express").RequestHandler} */
 export const chat = async (req, res) => {
   const normalizedMessages = normalizeMessages(req.body?.messages);


### PR DESCRIPTION
## Summary
- build helpers to format conversation history and render the Pokémon roleplay template
- derive species and friendship metadata from the active pet when crafting prompts
- send chat completions the new roleplay template alongside any persona context

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c8b898a81083229dab122303dbe541