### PR TITLE
Update chat interface styling

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Poke-Pet!</title>
+  <link rel="icon" type="image/png" href="images/favico.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+    rel="stylesheet"
+  >
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -1596,25 +1596,16 @@ function buildChatSection({ user, pet, backendURL }) {
     children: [inputField, sendButton],
   });
 
-  const headerChildren = [
-    createElement("div", {
-      className: "chat-header-title",
-      textContent: `Trainer: ${user.id}`,
-    }),
-  ];
-
-  if (pet) {
-    headerChildren.push(
-      createElement("div", {
-        className: "chat-header-subtitle",
-        textContent: `Chatting with ${pet.name}`,
-      }),
-    );
-  }
-
+  const fallbackCompanionName = pet ? resolvePetSpecies(pet) : "your companion";
+  const headerCompanionName = sanitizeIdentifier(pet?.name, fallbackCompanionName);
   const chatHeader = createElement("div", {
     className: "chat-header",
-    children: headerChildren,
+    children: [
+      createElement("div", {
+        className: "chat-header-title",
+        textContent: `Chatting with ${headerCompanionName}`,
+      }),
+    ],
   });
 
   const chatWrapper = createElement("div", {

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -3,18 +3,19 @@
 }
 
 :root {
-  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Prompt", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   color: #1f1f1f;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #d8d8d8;
+  background: #d8d8d8 url("images/bg.png") center / cover fixed no-repeat;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 48px 24px;
+  font-family: inherit;
 }
 
 #app {


### PR DESCRIPTION
## Summary
- apply the Prompt Google font, background artwork, and favicon to the static frontend shell
- simplify the chat header copy so it focuses on the active companion’s name
- remove the temporary favicon image asset until the final icon is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8dfef5f708322a8565af234b27743