### PR TITLE
Fix bootstrap user selection runtime error

### DIFF
--- a/backend/src/user/pet/petController.js
+++ b/backend/src/user/pet/petController.js
@@ -101,7 +101,7 @@ export const updatePet = async (req, res) => {
   }
 
   const updatedPet = {
-    _id: payload._id ?? id,
+    _id: id,
     name: rawName,
     stage: resolvedStage,
     friendship: resolvedFriendship,

--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -1100,8 +1100,8 @@ async function bootstrapUserSelection(appRoot, backendURL) {
       continue;
     }
 
-    if (existingUser) 
-      storeCachedUsername(existingUser.id ?? username);n
+    if (existingUser) {
+      storeCachedUsername(existingUser.id ?? username);
       return existingUser;
     }
 


### PR DESCRIPTION
## Summary
- wrap the existing-user branch in bootstrapUserSelection in braces
- remove the stray token that caused a ReferenceError at startup
- ensure pet updates keep their original identifier instead of accepting a payload-provided `_id`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8f4dfd47083228815cfc60900d64b