### PR TITLE
Update chat info labels

### DIFF
--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -1274,8 +1274,8 @@ function buildProfileColumn({ user, pet }) {
 
   const infoRows = [
     createInfoRow("Species", speciesFromPet),
-    createInfoRow("Owner", ownerId),
-    createInfoRow("Last-chatted", lastChattedDisplay),
+    createInfoRow("Trainer", ownerId),
+    createInfoRow("Last talked to", lastChattedDisplay),
   ];
 
   const talkingStreakDisplay = `${getTalkingStreakValue(activePet)} days`;
@@ -1571,21 +1571,16 @@ function buildChatSection({ user, pet, backendURL }) {
     children: [inputField, sendButton],
   });
 
+  const headerTitle = pet
+    ? `Chatting with ${companionDisplayName}`
+    : "Chatting with your companion";
+
   const headerChildren = [
     createElement("div", {
       className: "chat-header-title",
-      textContent: `Trainer: ${user.id}`,
+      textContent: headerTitle,
     }),
   ];
-
-  if (pet) {
-    headerChildren.push(
-      createElement("div", {
-        className: "chat-header-subtitle",
-        textContent: `Chatting with ${pet.name}`,
-      }),
-    );
-  }
 
   const chatHeader = createElement("div", {
     className: "chat-header",


### PR DESCRIPTION
## Summary
- update the pet info card to label the owner as trainer and rename the last-chatted field
- simplify the chat header to show a bold "Chatting with" title using the pet's display name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9042b89b48322a013cd37608319a5