### PR TITLE
Fix first message updates and evolution alerts

### DIFF
--- a/frontend/public/scripts/ui/chat.js
+++ b/frontend/public/scripts/ui/chat.js
@@ -140,7 +140,6 @@ export function buildChatSection({ user, pet, backendURL, onPetReleased }) {
 
   async function ensureFirstMessageUpdate() {
     if (hasUpdatedFirstMessage || !pet) {
-      hasUpdatedFirstMessage = true;
       return;
     }
 
@@ -171,9 +170,9 @@ export function buildChatSection({ user, pet, backendURL, onPetReleased }) {
       const message = error instanceof Error && error.message ? error.message : fallbackMessage;
       appendMessage({ sender: "System", message }, chatBox, displayMessages);
       throw error;
-    } finally {
-      hasUpdatedFirstMessage = true;
     }
+
+    hasUpdatedFirstMessage = true;
 
     pet.lastChatted = isoNow;
 

--- a/frontend/public/scripts/ui/profile.js
+++ b/frontend/public/scripts/ui/profile.js
@@ -14,7 +14,6 @@ function createInfoRow(label, value, options = {}) {
         textContent: value,
         attributes: valueAttributes,
       }),
-      createElement("span", { className: "info-value", textContent: value }),
     ],
   });
 }
@@ -74,12 +73,9 @@ export function buildProfileColumn({ user, pet, evolution = null }) {
   const activePet = pet ?? selectActivePet(user);
   const stageDetail = getStageDetail(activePet?.stage);
   const activePetId = sanitizeIdentifier(activePet?._id ?? activePet?.id, "");
-
-  const evolutionPetId =
-    evolution && typeof evolution.petId === "string" && evolution.petId.trim()
-      ? evolution.petId.trim()
-      : "";
-  const shouldShowEvolution = Boolean(activePet && activePetId && evolutionPetId && activePetId === evolutionPetId);
+  const evolutionPetId = sanitizeIdentifier(evolution?.petId, "");
+  const shouldShowEvolution =
+    Boolean(activePet && evolution) && (!activePetId || !evolutionPetId || activePetId === evolutionPetId);
 
   const petName =
     activePet && typeof activePet.name === "string" && activePet.name.trim()
@@ -175,12 +171,20 @@ export function buildProfileColumn({ user, pet, evolution = null }) {
         ? evolution.postImage
         : stageDetail.image;
 
-    setTimeout(() => {
+    const runEvolutionSequence = () => {
       window.alert("Your Pokemon is evolving!?");
       window.alert(`Congratulations, your pokemon has evolved into ${postSpecies}`);
       avatar.setAttribute("src", postImage);
       avatar.setAttribute("alt", `${postSpecies} avatar`);
-    }, 0);
+    };
+
+    if (typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(() => {
+        window.setTimeout(runEvolutionSequence, 0);
+      });
+    } else {
+      window.setTimeout(runEvolutionSequence, 0);
+    }
   }
 
   return column;

--- a/frontend/public/scripts/ui/prompts.js
+++ b/frontend/public/scripts/ui/prompts.js
@@ -173,7 +173,7 @@ export function showRunAwayPrompt(appRoot, petName) {
     });
 
     const button = createElement("button", {
-      className: "prompt-submit-button",
+      className: "prompt-submit-button prompt-runaway-button",
       textContent: "Ok..",
       attributes: {
         type: "button",
@@ -181,13 +181,13 @@ export function showRunAwayPrompt(appRoot, petName) {
       },
     });
 
-    const buttonWrapper = createElement("div", {
-      className: "prompt-input-wrapper",
-      children: [button],
-    });
-
     card.appendChild(title);
-    card.appendChild(buttonWrapper);
+    card.appendChild(
+      createElement("div", {
+        className: "prompt-runaway-actions",
+        children: [button],
+      }),
+    );
     container.appendChild(card);
     appRoot.appendChild(container);
 

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -126,6 +126,17 @@ body {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
+.prompt-runaway-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.prompt-runaway-button {
+  width: 96px;
+  height: 96px;
+  font-size: 28px;
+}
+
 .prompt-submit-button:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);


### PR DESCRIPTION
## Summary
- ensure the first chat message only marks the session update complete after the pet record is successfully patched so last-chatted and friendship adjustments are reliable
- make the evolution check more robust and trigger the alert sequence on the next frame so both pop-ups appear before swapping to the evolved avatar
- center the run-away prompt acknowledgement button on its own and double its dimensions so the white wrapper box no longer appears
- render each info value only once in the pet info card so the details no longer appear duplicated

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c92ed18c1483228fdcf914b755fd76