### PR TITLE
Update font and chat presentation

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Poke-Pet!</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+    rel="stylesheet"
+  >
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
 </head>

--- a/frontend/public/scripts/dom.js
+++ b/frontend/public/scripts/dom.js
@@ -35,14 +35,20 @@ export function createElement(tag, options = {}) {
 export function createMessageElement({ sender, message }) {
   const safeSender = typeof sender === "string" ? sender : String(sender ?? "");
   const safeMessage = typeof message === "string" ? message : String(message ?? "");
+  const trimmedSender = safeSender.trim();
+  const isSystemMessage = trimmedSender.toLowerCase() === "system";
 
   const messageElement = createElement("div", { className: "message" });
-  const senderElement = createElement("strong", {
-    textContent: `${safeSender}:`,
-  });
+  if (trimmedSender && !isSystemMessage) {
+    const senderElement = createElement("strong", {
+      textContent: `${trimmedSender}:`,
+    });
 
-  messageElement.appendChild(senderElement);
-  messageElement.appendChild(document.createTextNode(` ${safeMessage}`));
+    messageElement.appendChild(senderElement);
+    messageElement.appendChild(document.createTextNode(` ${safeMessage}`));
+  } else {
+    messageElement.appendChild(document.createTextNode(safeMessage));
+  }
 
   return messageElement;
 }

--- a/frontend/public/scripts/main.js
+++ b/frontend/public/scripts/main.js
@@ -30,6 +30,17 @@ function ensureCurrentUserBadge() {
   return badge;
 }
 
+function hideCurrentUserBadge() {
+  const badge = ensureCurrentUserBadge();
+
+  if (!badge) {
+    return;
+  }
+
+  badge.textContent = "";
+  badge.classList.add("is-hidden");
+}
+
 function updateCurrentUserBadge(username) {
   const badge = ensureCurrentUserBadge();
 
@@ -38,10 +49,12 @@ function updateCurrentUserBadge(username) {
   }
 
   const safeName = sanitizeIdentifier(username, "");
+  const isChatVisible = Boolean(
+    typeof document !== "undefined" && document.querySelector(".app-shell"),
+  );
 
-  if (!safeName) {
-    badge.textContent = "";
-    badge.classList.add("is-hidden");
+  if (!safeName || isChatVisible) {
+    hideCurrentUserBadge();
     return;
   }
 
@@ -236,6 +249,7 @@ async function initApp() {
 
   appRoot.innerHTML = "";
   appRoot.appendChild(root);
+  hideCurrentUserBadge();
 
   if (focusTarget) {
     focusTarget.focus();

--- a/frontend/public/scripts/ui/chat.js
+++ b/frontend/public/scripts/ui/chat.js
@@ -7,6 +7,7 @@ import {
   buildRoleplayPrompt,
   clampFriendship,
   formatConversationContext,
+  resolveFriendshipTier,
   sanitizeIdentifier,
 } from "../utils.js";
 
@@ -114,6 +115,13 @@ export function buildChatSection({ user, pet, backendURL, onPetReleased, onLogou
 
     if (friendshipProgressElement) {
       friendshipProgressElement.style.width = `${boundedFriendship}%`;
+      friendshipProgressElement.classList.remove(
+        "friendship-low",
+        "friendship-medium",
+        "friendship-high",
+      );
+      const tierClass = `friendship-${resolveFriendshipTier(boundedFriendship)}`;
+      friendshipProgressElement.classList.add(tierClass);
     }
   }
 

--- a/frontend/public/scripts/ui/profile.js
+++ b/frontend/public/scripts/ui/profile.js
@@ -1,6 +1,11 @@
 import { createElement } from "../dom.js";
 import { getStageDetail, selectActivePet } from "../pets.js";
-import { clampFriendship, getTalkingStreakValue, sanitizeIdentifier } from "../utils.js";
+import {
+  clampFriendship,
+  getTalkingStreakValue,
+  resolveFriendshipTier,
+  sanitizeIdentifier,
+} from "../utils.js";
 
 function createInfoRow(label, value, options = {}) {
   const { valueAttributes = {} } = options;
@@ -34,8 +39,9 @@ function buildFriendshipSection(friendshipValue) {
     ],
   });
   const bar = createElement("div", { className: "friendship-bar" });
+  const tier = resolveFriendshipTier(clampedValue);
   const fill = createElement("div", {
-    className: "friendship-bar-fill",
+    className: `friendship-bar-fill friendship-${tier}`,
     attributes: { "data-info": "friendship-progress" },
   });
   fill.style.width = `${clampedValue}%`;

--- a/frontend/public/scripts/utils.js
+++ b/frontend/public/scripts/utils.js
@@ -39,6 +39,20 @@ export function clampFriendship(value) {
   return Math.max(0, Math.min(100, Math.round(numeric)));
 }
 
+export function resolveFriendshipTier(value) {
+  const bounded = clampFriendship(value);
+
+  if (bounded <= 33) {
+    return "low";
+  }
+
+  if (bounded <= 66) {
+    return "medium";
+  }
+
+  return "high";
+}
+
 export function formatConversationContext(history, { trainerName, petName }) {
   const safeTrainerName = sanitizeIdentifier(trainerName, "Trainer");
   const safePetName = sanitizeIdentifier(petName, "Companion");

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -3,7 +3,7 @@
 }
 
 :root {
-  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Prompt", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   color: #1f1f1f;
 }
 
@@ -249,8 +249,20 @@ body {
 .friendship-bar-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, #81c784 0%, #43a047 100%);
-  transition: width 0.3s ease;
+  background-color: #43a047;
+  transition: width 0.3s ease, background-color 0.3s ease;
+}
+
+.friendship-bar-fill.friendship-low {
+  background-color: #e53935;
+}
+
+.friendship-bar-fill.friendship-medium {
+  background-color: #fbc02d;
+}
+
+.friendship-bar-fill.friendship-high {
+  background-color: #43a047;
 }
 
 .friendship-value {


### PR DESCRIPTION
## Summary
- switch the frontend to use the Prompt Google font and load it in the document head
- hide the "currently logged in" badge once the chat renders and drop the "System:" label from system messages
- color the friendship bar fill red, yellow, or green based on the current friendship score

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c95a4d91fc832296ee6e2347604b87